### PR TITLE
docs(README.md): added `:` in L29

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ import { SentryTransport } from 'winston-sentry-javascript-node';
 const logger = winston.createLogger({
   transports: [
     new SentryTransport({
-      sentry{
+      sentry:{
         dsn: 'MY_SENTRY_DSN',
       },
     }),


### PR DESCRIPTION
added missed `:` in L29 to
```js
...
sentry:{
        dsn: 'MY_SENTRY_DSN',
      },
...
```